### PR TITLE
Add more tests for s3 backend and k8scontrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jupyterhub-kubernetes-backup
 
+[![codecov](https://codecov.io/gh/jonstacks/jupyterhub-kubernetes-backup/branch/master/graph/badge.svg)](https://codecov.io/gh/jonstacks/jupyterhub-kubernetes-backup)
+
 Backup PVCs created by jupyterhub to S3(the only backend supported right now).
 
 <!-- TOC -->

--- a/pkg/backend/s3.go
+++ b/pkg/backend/s3.go
@@ -11,9 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
+type s3Uploader interface {
+	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+}
+
 // S3 is an AWS S3 backend for storing the files
 type S3 struct {
-	uploader *s3manager.Uploader
+	uploader s3Uploader
 	bucket   string
 	prefix   string
 }

--- a/pkg/backend/s3_test.go
+++ b/pkg/backend/s3_test.go
@@ -1,11 +1,51 @@
 package backend
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/stretchr/testify/assert"
 )
 
+type testS3Uploader struct {
+	injectError bool
+}
+
+func (uploader testS3Uploader) Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+	if uploader.injectError {
+		return nil, fmt.Errorf("an injected error occurred")
+	}
+	return nil, nil
+}
+
 func TestS3ImplementsBackend(t *testing.T) {
 	assert.Implements(t, (*Backend)(nil), new(S3))
+}
+
+func TestSaveReturnsNilWhenNoErrors(t *testing.T) {
+	uploader := testS3Uploader{injectError: false}
+
+	s3 := &S3{
+		uploader: uploader,
+		bucket:   "test-bucket",
+		prefix:   "my-prefix",
+	}
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, s3.Save(wd))
+}
+
+func TestSaveReturnsErrorWhenUploadErrorOccurs(t *testing.T) {
+	uploader := testS3Uploader{injectError: true}
+
+	s3 := &S3{
+		uploader: uploader,
+		bucket:   "test-bucket",
+		prefix:   "my-prefix",
+	}
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.Error(t, s3.Save(wd))
 }

--- a/pkg/k8scontrib/kubernetes.go
+++ b/pkg/k8scontrib/kubernetes.go
@@ -1,13 +1,16 @@
 package k8scontrib
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/spf13/afero"
 )
 
 // NamespaceFile is the path of the file that kubernetes stores the namespace in
 const NamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+var fs = afero.Afero{Fs: afero.NewOsFs()}
 
 // Namespace returns the namespace of the current running pod
 func Namespace() string {
@@ -15,7 +18,7 @@ func Namespace() string {
 		return ns
 	}
 
-	if data, err := ioutil.ReadFile(NamespaceFile); err == nil {
+	if data, err := fs.ReadFile(NamespaceFile); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns
 		}

--- a/pkg/k8scontrib/kubernetes_test.go
+++ b/pkg/k8scontrib/kubernetes_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +25,10 @@ func TestNamespaceFromEnvironment(t *testing.T) {
 	})
 
 	assert.Equal(t, "default", Namespace())
+}
+
+func TestNamespaceFromFile(t *testing.T) {
+	fs = afero.Afero{Fs: afero.NewMemMapFs()}
+	fs.WriteFile(NamespaceFile, []byte("my-namespace-from-file"), 0644)
+	assert.Equal(t, "my-namespace-from-file", Namespace())
 }


### PR DESCRIPTION
Increase test coverage by mocking the s3 uploader for the s3 backend.
Increase test coverage by mocking the filesystem for `k8scontrib.Namespace`.