### PR TITLE
Add node affinity for backup job if user's jupyter notebook is currently running

### DIFF
--- a/chart/jupyterhub-kubernetes-backup/templates/serviceaccount.yaml
+++ b/chart/jupyterhub-kubernetes-backup/templates/serviceaccount.yaml
@@ -19,8 +19,9 @@ rules:
   verbs: ["create", "get", "list", "watch", "delete"]
 - apiGroups: [""]
   resources:
+  - pods
   - persistentvolumeclaims
-  verbs: ["list"]
+  verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding

--- a/pkg/backend/s3_test.go
+++ b/pkg/backend/s3_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,6 +23,14 @@ func (uploader testS3Uploader) Upload(*s3manager.UploadInput, ...func(*s3manager
 
 func TestS3ImplementsBackend(t *testing.T) {
 	assert.Implements(t, (*Backend)(nil), new(S3))
+}
+
+func TestNewS3(t *testing.T) {
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+	s3 := NewS3(sess, "my-test-bucket", "my-test/prefix")
+	assert.Equal(t, s3.bucket, "my-test-bucket")
 }
 
 func TestSaveReturnsNilWhenNoErrors(t *testing.T) {


### PR DESCRIPTION
Fixes #14 

This adds an affinity with a NodeSelector to the backup pod telling the scheduler that it would like it to go on the same node as the user's running jupyter pod. This helps when the pvc is `ReadWriteOnce`, since it can only be attached to a single node.

Also, we add permissions to the helm chart, and mount the volume as `ReadOnly`.