### PR TITLE
Use Local ETag calculation to determine if we should re-upload or not

### DIFF
--- a/chart/jupyterhub-kubernetes-backup/templates/cron-job.yaml
+++ b/chart/jupyterhub-kubernetes-backup/templates/cron-job.yaml
@@ -38,6 +38,10 @@ spec:
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
             - name: BACKEND
               value: "{{ .Values.backend.type }}"
+            - name: LOG_LEVEL
+              value: "{{ .Values.log.level }}"
+            - name: LOG_FORMAT
+              value: "{{ .Values.log.format }}"
             {{- if .Values.backend.s3 }}
             {{- if .Values.backend.s3.bucket }}
             - name: BACKEND_S3_BUCKET

--- a/chart/jupyterhub-kubernetes-backup/values.yaml
+++ b/chart/jupyterhub-kubernetes-backup/values.yaml
@@ -39,3 +39,7 @@ resources: {}
 cronJob:
   concurrencyPolicy: Forbid
   schedule: "0/30 * * * *" # Run every 30 minutes
+
+log:
+  level: INFO
+  format: TEXT

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.34.21
+	github.com/peakgames/s3hash v0.1.1
 	github.com/spf13/afero v1.3.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.34.21
 	github.com/peakgames/s3hash v0.1.1
+	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/afero v1.3.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
@@ -144,6 +146,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.3.5 h1:AWZ/w4lcfxuh52NVL78p9Eh8j6r1mCTEGSRFBJyIHAE=
 github.com/spf13/afero v1.3.5/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
@@ -151,6 +155,7 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
@@ -219,6 +224,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/peakgames/s3hash v0.1.1 h1:XHK/BP0tAmvUSF+pDAtup+SFLjoA43nqMOzhaFQ6CUc=
+github.com/peakgames/s3hash v0.1.1/go.mod h1:pfK7xgDV5xE8Yo+pfZ0Tmg3GXbbYMZxoWqfzkmIYIRc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -1,10 +1,10 @@
 package backend
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 
@@ -32,7 +32,7 @@ func (m Mock) Save(basePath string) error {
 		}
 
 		if info.IsDir() {
-			log.Printf("Entering directory: %s", path)
+			logrus.Debugf("Entering directory: %s", path)
 			return nil
 		}
 
@@ -41,7 +41,7 @@ func (m Mock) Save(basePath string) error {
 			return err
 		}
 
-		log.Printf("Processing file %s", rel)
+		logrus.Infof("Processing file %s", rel)
 		return nil
 	})
 }

--- a/pkg/backend/s3.go
+++ b/pkg/backend/s3.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -105,7 +106,7 @@ func (s S3) isObjectDirty(key string, path string) bool {
 		return true
 	}
 
-	s3Etag := aws.StringValue(resp.ETag)
+	s3Etag := strings.Trim(aws.StringValue(resp.ETag), "\"")
 	localEtag, err := s3hash.Calculate(bytes.NewReader(fileContents), s3manager.DefaultUploadPartSize)
 	if err != nil {
 		return true

--- a/pkg/backend/s3_test.go
+++ b/pkg/backend/s3_test.go
@@ -92,7 +92,7 @@ func (suite *S3BackendSuite) SetupTest() {
 		injectError: false,
 		responses: map[string]*s3.HeadObjectOutput{
 
-			suite.fullKeyPath("test1.txt"):           {ETag: aws.String("88c16a56754e0f17a93d269ae74dde9b")},
+			suite.fullKeyPath("test1.txt"):           {ETag: aws.String("\"88c16a56754e0f17a93d269ae74dde9b\"")},
 			suite.fullKeyPath("test2.txt"):           {ETag: aws.String("")},
 			suite.fullKeyPath("subfolder/test3.txt"): {ETag: aws.String("")},
 		},

--- a/pkg/backend/s3_test.go
+++ b/pkg/backend/s3_test.go
@@ -2,59 +2,171 @@ package backend
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/stretchr/testify/assert"
+	"github.com/jonstacks/jupyterhub-kubernetes-backup/pkg/core"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/suite"
 )
 
 type testS3Uploader struct {
 	injectError bool
 }
 
-func (uploader testS3Uploader) Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+func (uploader *testS3Uploader) Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
 	if uploader.injectError {
 		return nil, fmt.Errorf("an injected error occurred")
 	}
 	return nil, nil
 }
 
-func TestS3ImplementsBackend(t *testing.T) {
-	assert.Implements(t, (*Backend)(nil), new(S3))
+type testS3Client struct {
+	injectError bool
+	responses   map[string]*s3.HeadObjectOutput
 }
 
-func TestNewS3(t *testing.T) {
+func (client *testS3Client) HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	if client.responses != nil && input.Key != nil {
+		output, ok := client.responses[aws.StringValue(input.Key)]
+		if ok {
+			return output, nil
+		}
+	}
+	return nil, nil
+}
+
+type S3BackendSuite struct {
+	suite.Suite
+
+	bucket          string
+	prefix          string
+	localBackupPath string
+
+	fullKeyPath   func(string) string
+	fullLocalPath func(string) string
+
+	noErrorS3Client   *testS3Client
+	errorS3Client     *testS3Client
+	noErrorS3Uploader *testS3Uploader
+	errorS3Uploader   *testS3Uploader
+
+	defaultClient     *S3
+	uploadErrorClient *S3
+}
+
+func (suite *S3BackendSuite) SetupTest() {
+	suite.bucket = "test-bucket"
+	suite.prefix = "my-prefix"
+	suite.localBackupPath = "/backup"
+
+	suite.fullKeyPath = func(path string) string {
+		return fmt.Sprintf("%s/%s", suite.prefix, path)
+	}
+
+	suite.fullLocalPath = func(path string) string {
+		return fmt.Sprintf("%s/%s", suite.localBackupPath, path)
+	}
+
+	// Set up an in memory filesystem that the S3 Backend will use
+	// This prevents collisions with any user files and having to clean
+	// up the filesystem when we are done.
+	core.Filesystem = &afero.Afero{Fs: afero.NewMemMapFs()}
+
+	suite.NoError(core.Filesystem.MkdirAll("/backup/subfolder", 0755))
+
+	files := map[string][]byte{
+		suite.fullLocalPath("test1.txt"):           []byte("This is file 1\n"),
+		suite.fullLocalPath("test2.txt"):           []byte("This is file 2\n"),
+		suite.fullLocalPath("subfolder/test3.txt"): []byte("This is file 3\n"),
+	}
+
+	for filename, contents := range files {
+		suite.NoError(core.Filesystem.WriteFile(filename, contents, 0755))
+	}
+
+	suite.noErrorS3Client = &testS3Client{
+		injectError: false,
+		responses: map[string]*s3.HeadObjectOutput{
+
+			suite.fullKeyPath("test1.txt"):           {ETag: aws.String("88c16a56754e0f17a93d269ae74dde9b")},
+			suite.fullKeyPath("test2.txt"):           {ETag: aws.String("")},
+			suite.fullKeyPath("subfolder/test3.txt"): {ETag: aws.String("")},
+		},
+	}
+	suite.errorS3Client = &testS3Client{injectError: true}
+	suite.noErrorS3Uploader = &testS3Uploader{injectError: false}
+	suite.errorS3Uploader = &testS3Uploader{injectError: true}
+
+	suite.defaultClient = &S3{
+		client:   suite.noErrorS3Client,
+		uploader: suite.noErrorS3Uploader,
+		bucket:   suite.bucket,
+		prefix:   suite.prefix,
+	}
+
+	suite.uploadErrorClient = &S3{
+		client:   suite.noErrorS3Client,
+		uploader: suite.errorS3Uploader,
+		bucket:   suite.bucket,
+		prefix:   suite.prefix,
+	}
+}
+
+func (suite *S3BackendSuite) TestImplementsBackend() {
+	suite.Implements((*Backend)(nil), new(S3))
+}
+
+func (suite *S3BackendSuite) TestNewS3() {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
-	s3 := NewS3(sess, "my-test-bucket", "my-test/prefix")
-	assert.Equal(t, s3.bucket, "my-test-bucket")
+	s3 := NewS3(sess, suite.bucket, suite.prefix)
+	suite.Equal(s3.bucket, suite.bucket)
+	suite.Equal(s3.prefix, suite.prefix)
 }
 
-func TestSaveReturnsNilWhenNoErrors(t *testing.T) {
-	uploader := testS3Uploader{injectError: false}
-
-	s3 := &S3{
-		uploader: uploader,
-		bucket:   "test-bucket",
-		prefix:   "my-prefix",
-	}
-	wd, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, s3.Save(wd))
+func (suite *S3BackendSuite) TestSaveReturnsNilWhenNoErrors() {
+	suite.NoError(suite.defaultClient.Save(suite.localBackupPath))
 }
 
-func TestSaveReturnsErrorWhenUploadErrorOccurs(t *testing.T) {
-	uploader := testS3Uploader{injectError: true}
+func (suite *S3BackendSuite) TestSaveReturnsErrorWhenUploadErrorOccurs() {
+	suite.Error(suite.uploadErrorClient.Save(suite.localBackupPath))
+}
 
-	s3 := &S3{
-		uploader: uploader,
-		bucket:   "test-bucket",
-		prefix:   "my-prefix",
+func (suite *S3BackendSuite) TestSaveReturnsErrorWhenFileIsGivenInsteadOfDirectory() {
+	suite.Error(suite.defaultClient.Save("/badpath"))
+}
+
+func (suite *S3BackendSuite) TestIsObjectDirtyReturnsFalseIfETagsMatch() {
+	// test1.txt's ETag should match, so no new upload should be necessary.
+	suite.False(suite.defaultClient.isObjectDirty(
+		suite.fullKeyPath("test1.txt"),
+		suite.fullLocalPath("test1.txt"),
+	))
+}
+
+func (suite *S3BackendSuite) TestIsObjectDirty() {
+
+	trueTestCases := [][2]string{
+		{"notFound.txt", "test2.txt"},
+		{"test2.txt", "notFound.txt"},
+		{"test2.txt", "test2.txt"},
 	}
-	wd, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.Error(t, s3.Save(wd))
+
+	for _, tc := range trueTestCases {
+		suite.True(
+			suite.defaultClient.isObjectDirty(
+				suite.fullKeyPath(tc[0]),
+				suite.fullLocalPath(tc[1]),
+			),
+		)
+	}
+}
+
+func TestS3BackendSuite(t *testing.T) {
+	suite.Run(t, new(S3BackendSuite))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,9 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Default config constants
@@ -18,6 +21,14 @@ const (
 	AwsAccessKeyID     = "AWS_ACCESS_KEY_ID"
 	AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 	AwsDefaultRegion   = "AWS_DEFAULT_REGION"
+
+	LogLevel  = "LOG_LEVEL"
+	LogFormat = "LOG_FORMAT"
+)
+
+var (
+	defaultLogLevel     = logrus.InfoLevel
+	defaultLogFormatter = &logrus.TextFormatter{}
 )
 
 // Get gets the environment variable by name
@@ -37,4 +48,27 @@ func GetDefault(name string, defaultValue string) string {
 // the s3 prefix for uploads.
 func GetS3UserPrefix() string {
 	return fmt.Sprintf("%s/%s", Get(BackendS3Prefix), Get(BackupUsername))
+}
+
+// GetLogLevel returns the log level from the environment
+func GetLogLevel() logrus.Level {
+	lvl := os.Getenv(LogLevel)
+	if lvl != "" {
+		level, err := logrus.ParseLevel(lvl)
+		if err == nil {
+			return level
+		}
+		logrus.Errorf("Error parsing LOG_LEVEL='%s' from environment. Defaulting to INFO", lvl)
+	}
+	return defaultLogLevel
+}
+
+// GetLogFormatter returns the log formatter from the environment
+func GetLogFormatter() logrus.Formatter {
+	fmt := os.Getenv(LogFormat)
+	switch strings.ToLower(fmt) {
+	case "json":
+		return &logrus.JSONFormatter{}
+	}
+	return defaultLogFormatter
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,4 +35,39 @@ func TestGetDefault(t *testing.T) {
 		assert.Equal(t, "my-backend", GetDefault(Backend, "mock"))
 		assert.Equal(t, "defaultValue", GetDefault(LocalPath, "defaultValue"))
 	})
+}
+
+func TestGetLogLevel(t *testing.T) {
+	tests := map[string]logrus.Level{
+		"":      logrus.InfoLevel, // Default
+		"PANIC": logrus.PanicLevel,
+		"DEBUG": logrus.DebugLevel,
+		"TRACE": logrus.TraceLevel,
+		"ERROR": logrus.ErrorLevel,
+		"INFO":  logrus.InfoLevel,
+		"BAD":   logrus.InfoLevel,
+	}
+	for env, lvl := range tests {
+		withEnv(map[string]string{
+			LogLevel: env,
+		}, func() {
+			assert.Equal(t, lvl, GetLogLevel())
+		})
+	}
+}
+
+func TestGetLogFormatter(t *testing.T) {
+	tests := map[string]logrus.Formatter{
+		"":     &logrus.TextFormatter{}, // Default
+		"TEXT": &logrus.TextFormatter{},
+		"JSON": &logrus.JSONFormatter{},
+	}
+
+	for env, fmt := range tests {
+		withEnv(map[string]string{
+			LogFormat: env,
+		}, func() {
+			assert.Equal(t, fmt, GetLogFormatter())
+		})
+	}
 }

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,0 +1,11 @@
+package core
+
+import "github.com/sirupsen/logrus"
+
+// FatalIfError will log a message at the fatal error and exit if the
+// error is not nil
+func FatalIfError(err error) {
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/pkg/core/filesystem.go
+++ b/pkg/core/filesystem.go
@@ -1,0 +1,9 @@
+package core
+
+import "github.com/spf13/afero"
+
+// Filesystem is the project wide abstraction for dealing with the filesystem.
+// We'll use the to easily swap our the real filesystem for an in-memory
+// one during tests, so the user doesn't actually have to have permissions
+// to write to the real paths on the host.
+var Filesystem = &afero.Afero{Fs: afero.NewOsFs()}

--- a/pkg/k8scontrib/kubernetes.go
+++ b/pkg/k8scontrib/kubernetes.go
@@ -4,13 +4,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/afero"
+	"github.com/jonstacks/jupyterhub-kubernetes-backup/pkg/core"
 )
 
 // NamespaceFile is the path of the file that kubernetes stores the namespace in
 const NamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-
-var fs = afero.Afero{Fs: afero.NewOsFs()}
 
 // Namespace returns the namespace of the current running pod
 func Namespace() string {
@@ -18,7 +16,7 @@ func Namespace() string {
 		return ns
 	}
 
-	if data, err := fs.ReadFile(NamespaceFile); err == nil {
+	if data, err := core.Filesystem.ReadFile(NamespaceFile); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns
 		}

--- a/pkg/k8scontrib/kubernetes_test.go
+++ b/pkg/k8scontrib/kubernetes_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jonstacks/jupyterhub-kubernetes-backup/pkg/core"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,7 +29,7 @@ func TestNamespaceFromEnvironment(t *testing.T) {
 }
 
 func TestNamespaceFromFile(t *testing.T) {
-	fs = afero.Afero{Fs: afero.NewMemMapFs()}
-	fs.WriteFile(NamespaceFile, []byte("my-namespace-from-file"), 0644)
+	core.Filesystem = &afero.Afero{Fs: afero.NewMemMapFs()}
+	core.Filesystem.WriteFile(NamespaceFile, []byte("my-namespace-from-file"), 0644)
 	assert.Equal(t, "my-namespace-from-file", Namespace())
 }


### PR DESCRIPTION
Fixes #15 

* See if we can HEAD the object in s3 to get its remote ETag, using this we can also calculate a local ETag to see if we need to re-upload the file or not.
* Use logrus for logging so that we can can change log level easier.