### PR TITLE
Allow for specifying required affinity and copying tolerations

### DIFF
--- a/chart/jupyterhub-kubernetes-backup/templates/cron-job.yaml
+++ b/chart/jupyterhub-kubernetes-backup/templates/cron-job.yaml
@@ -42,6 +42,8 @@ spec:
               value: "{{ .Values.log.level }}"
             - name: LOG_FORMAT
               value: "{{ .Values.log.format }}"
+            - name: BACKUP_POD_NODE_AFFINITY
+              value: "{{ .Values.backup.podNodeAffinity }}"
             {{- if .Values.backend.s3 }}
             {{- if .Values.backend.s3.bucket }}
             - name: BACKEND_S3_BUCKET

--- a/chart/jupyterhub-kubernetes-backup/values.yaml
+++ b/chart/jupyterhub-kubernetes-backup/values.yaml
@@ -24,6 +24,12 @@ backend:
   #   secret: my-secret
   #   region: us-west-2
 
+backup:
+  # required means that if a user's jupyterhub pod is running, the backup job will be created
+  # with a NodeAffinity that is required during scheduling. Setting it to preferred or anything
+  # else but an empty string will change the NodeAffinity to preferred during scheduling.
+  podNodeAffinity: required
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/pkg/backup/pod_affinity.go
+++ b/pkg/backup/pod_affinity.go
@@ -1,0 +1,51 @@
+package backup
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetNodeAffinityForBackupPod returns an Affinity for the backup pod given the
+// nodeName that the user's jupyter pod is running on. If required is true, a
+// NodeAffinity with a RequiredDuringSchedulingIgnoredDuringExecution will be
+// returned, otherwise a NodeAffinity with
+// PreferredDuringSchedulingIgnoredDuringExecution will be returned.
+func GetNodeAffinityForBackupPod(nodeName string, required bool) *corev1.Affinity {
+	if nodeName == "" {
+		return nil
+	}
+
+	nodeSelectorTerm := corev1.NodeSelectorTerm{
+		// Add a match field which matches the node's metadata.name field to the
+		// nodename the pod is running on.
+		MatchFields: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "metadata.name",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{nodeName},
+			},
+		},
+	}
+
+	if required {
+		return &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						nodeSelectorTerm,
+					},
+				},
+			},
+		}
+	}
+
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+				{
+					Weight:     1,
+					Preference: nodeSelectorTerm,
+				},
+			},
+		},
+	}
+}

--- a/pkg/backup/pod_affinity_test.go
+++ b/pkg/backup/pod_affinity_test.go
@@ -1,0 +1,83 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetNodeAffinityForBackupPod(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodeName string
+		required bool
+		expected *corev1.Affinity
+	}{
+		{
+			name:     "EmptyNodeNameAndPreferredAffinity",
+			nodeName: "",
+			required: false,
+			expected: nil,
+		},
+		{
+			name:     "EmptyNodeNameAndRequiredAffinity",
+			nodeName: "",
+			required: true,
+			expected: nil,
+		},
+		{
+			name:     "NonEmptyNodeNameAndPreferredAffinity",
+			nodeName: "node1",
+			required: false,
+			expected: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+						{
+							Weight: 1,
+							Preference: corev1.NodeSelectorTerm{
+								MatchFields: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "metadata.name",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"node1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "NonEmptyNodeNameAndPreferredAffinity",
+			nodeName: "node1",
+			required: true,
+			expected: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchFields: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "metadata.name",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"node1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, GetNodeAffinityForBackupPod(tc.nodeName, tc.required))
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,8 +10,9 @@ import (
 
 // Default config constants
 const (
-	LocalPath      = "LOCAL_PATH"
-	BackupUsername = "BACKUP_USERNAME"
+	LocalPath             = "LOCAL_PATH"
+	BackupUsername        = "BACKUP_USERNAME"
+	BackupPodNodeAffinity = "BACKUP_POD_NODE_AFFINITY"
 
 	Backend         = "BACKEND"
 	DefaultBackend  = "mock"
@@ -71,4 +72,14 @@ func GetLogFormatter() logrus.Formatter {
 		return &logrus.JSONFormatter{}
 	}
 	return defaultLogFormatter
+}
+
+// GetBackupPodNodeAffinityRequired returns true if the config indicates that
+// we should require the nodeAffinity for the backup pod as opposed to just preferring it.
+func GetBackupPodNodeAffinityRequired() bool {
+	val := strings.TrimSpace(os.Getenv(BackupPodNodeAffinity))
+	if val == "" {
+		return true // default value
+	}
+	return strings.ToLower(val) == "required"
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,3 +71,20 @@ func TestGetLogFormatter(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBackupPodNodeAffinityRequired(t *testing.T) {
+	tests := map[string]bool{
+		"":          true,
+		"preferred": false,
+		"PREFERRED": false,
+		"required":  true,
+		"REQUIRED":  true,
+	}
+	for env, expected := range tests {
+		withEnv(map[string]string{
+			BackupPodNodeAffinity: env,
+		}, func() {
+			assert.Equal(t, expected, GetBackupPodNodeAffinityRequired())
+		})
+	}
+}


### PR DESCRIPTION
This changes the affinity on the backup pods to be a NodeAffinity with `RequiredDuringSchedulingIgnoredDuringExecution` and also copies over any tolerations that exist on the pod in case the user's pod tolerates spot nodes, etc.