### PR TITLE
Issue #21 Cleanup backup pods the have completed successfully

### DIFF
--- a/chart/jupyterhub-kubernetes-backup/templates/serviceaccount.yaml
+++ b/chart/jupyterhub-kubernetes-backup/templates/serviceaccount.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
+  verbs: ["list", "get", "delete"]
+- apiGroups: [""]
+  resources:
   - persistentvolumeclaims
   verbs: ["list", "get"]
 ---


### PR DESCRIPTION
The backup launcher job will now clean up successful backup pods before it exits. This will help a user more easily identify the backups that have failed.